### PR TITLE
Add current working directory as variable

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -67,7 +67,7 @@ import Skylighting.Parser (addSyntaxDefinition, missingIncludes,
                            parseSyntaxDefinition)
 import System.Console.GetOpt
 import System.Directory (Permissions (..), doesFileExist, findExecutable,
-                         getAppUserDataDirectory, getPermissions)
+                         getAppUserDataDirectory, getCurrentDirectory, getPermissions)
 import System.Environment (getArgs, getEnvironment, getProgName)
 import System.Exit (ExitCode (..), exitSuccess)
 import System.FilePath
@@ -350,6 +350,9 @@ convertWithOpts opts = do
                  (optIncludeInHeader opts)
         >>=
         withList (addStringAsVariable "css") (optCss opts)
+        >>=
+        maybe return (addStringAsVariable "pwd")
+                     (getCurrentDirectory opts)
         >>=
         maybe return (addStringAsVariable "title-prefix")
                      (optTitlePrefix opts)


### PR DESCRIPTION
As described in #5464, this adds `$pwd$` as template variable so files in the current path can be used e.g. even if a tex file is compiled in another folder.